### PR TITLE
Fix hex calculator element in Bootstrap 5

### DIFF
--- a/elements/pl-hex-calculator/pl-hex-calculator.js
+++ b/elements/pl-hex-calculator/pl-hex-calculator.js
@@ -293,7 +293,7 @@ class OperationController {
         } else {
             window.addEventListener('DOMContentLoaded', (e) => {
                 new CalculatorController(uuid)
-            }, { once: true });
+            });
         }
     }
 }
@@ -590,7 +590,7 @@ class CalculatorController {
             // Initialize calculator as soon as everything we need is loaded
             window.addEventListener('DOMContentLoaded', (e) => {
                 new CalculatorController(uuid)
-            }, { once: true });
+            });
         }
     }
 }
@@ -601,4 +601,4 @@ var ready = false;
 
 window.addEventListener('DOMContentLoaded', (e) => {
     ready = true
-}, { once: true });
+});

--- a/elements/pl-hex-calculator/pl-hex-calculator.js
+++ b/elements/pl-hex-calculator/pl-hex-calculator.js
@@ -293,7 +293,7 @@ class OperationController {
         } else {
             window.addEventListener('DOMContentLoaded', (e) => {
                 new CalculatorController(uuid)
-            }, 'once');
+            });
         }
     }
 }
@@ -590,7 +590,7 @@ class CalculatorController {
             // Initialize calculator as soon as everything we need is loaded
             window.addEventListener('DOMContentLoaded', (e) => {
                 new CalculatorController(uuid)
-            }, 'once');
+            });
         }
     }
 }
@@ -601,4 +601,4 @@ var ready = false;
 
 window.addEventListener('DOMContentLoaded', (e) => {
     ready = true
-}, 'once');
+});

--- a/elements/pl-hex-calculator/pl-hex-calculator.js
+++ b/elements/pl-hex-calculator/pl-hex-calculator.js
@@ -293,7 +293,7 @@ class OperationController {
         } else {
             window.addEventListener('DOMContentLoaded', (e) => {
                 new CalculatorController(uuid)
-            });
+            }, { once: true });
         }
     }
 }
@@ -590,7 +590,7 @@ class CalculatorController {
             // Initialize calculator as soon as everything we need is loaded
             window.addEventListener('DOMContentLoaded', (e) => {
                 new CalculatorController(uuid)
-            });
+            }, { once: true });
         }
     }
 }
@@ -601,4 +601,4 @@ var ready = false;
 
 window.addEventListener('DOMContentLoaded', (e) => {
     ready = true
-});
+}, { once: true });


### PR DESCRIPTION
The pl-hex-calculator was failing in Bootstrap 5. The culprit seems to be the fact that Bootstrap 5 loads the jQuery functions (e.g., `$().popover`) on document load's bubbling phase, not capture phase. The code was actually incorrectly setting the once option, causing the handler to run too early, before the functions were loaded.